### PR TITLE
feat: add zenodo doi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unCover
+# unCover [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13845956.svg)](https://doi.org/10.5281/zenodo.13845956)
 
 Detailed information about unCover can be found in the following publication:
 


### PR DESCRIPTION
badge for repository was only available after first release since linking the accounts